### PR TITLE
Replace newline in diagnostic message with `. ` for better readability

### DIFF
--- a/lua/lualine/components/diagnostic-message.lua
+++ b/lua/lualine/components/diagnostic-message.lua
@@ -84,7 +84,7 @@ function diagnostics_message:update_status(is_focused)
 		return highlight.component_format_highlight(hl[top.severity])
 			.. icons[top.severity]
 			.. " "
-			.. utils.stl_escape(top.message:gsub("[%c]", ""))
+			.. utils.stl_escape(top.message:gsub("[\n]", ". "):gsub("[%c]", ""))
 	else
 		return ""
 	end


### PR DESCRIPTION
For example with the following diagnostic message from Deno:

![{107B8B58-0D34-462B-AD57-69B4A145DD3D}](https://github.com/user-attachments/assets/d8f01337-247f-44f2-ae4b-dcbb475db485)

The current `lualine-diagnostic-message` displays it as this, which is not readable in my opinion.

![{6AD2D880-3E8C-4105-9489-73EAB3E3D100}](https://github.com/user-attachments/assets/3ad3e841-cc0b-40af-8c35-45d5a5ade19a)

This PR changes it to

![{F1ED8498-0050-4113-AFE8-7DA099928A15}](https://github.com/user-attachments/assets/fa517526-5d43-4f24-948c-d4f393f818ba)
